### PR TITLE
fixes#18fixed users login another

### DIFF
--- a/spec/features/users_login_spec.rb
+++ b/spec/features/users_login_spec.rb
@@ -57,6 +57,6 @@ RSpec.feature 'UsersLogin', type: :feature do
 
   it 'login without remembering' do
     sign_in_as(@user, remember_me: '0')
-    expect(page.driver.cookies['remember_token']).to be_nil
+    expect(page.driver.cookies['remember_token']).to be_blank
   end
 end

--- a/spec/features/users_login_spec.rb
+++ b/spec/features/users_login_spec.rb
@@ -56,8 +56,7 @@ RSpec.feature 'UsersLogin', type: :feature do
   end
 
   it 'login without remembering' do
-    pending('no method cookies')
     sign_in_as(@user, remember_me: '0')
-    expect(cookies['remember_token']).to be_nil
+    expect(page.driver.cookies['remember_token']).to be_nil
   end
 end


### PR DESCRIPTION
# 対象issue
#18 #42
# 対応内容
users_login_specのlogin without rememberingをエラー修正いたしました。
確認よろしくお願い致します。
# 備考

