### PR TITLE
fixes#35#36fixed users-controller

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,63 +1,113 @@
 require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
-  let!(:user) { create :tsubasa }
-  let(:other_user) { create :sayami }
-
-  it 'should redirect index when not logged in' do
-    get :index
-    expect(response).to redirect_to login_url
+  context 'index when not logged in' do
+    before do
+      get :index
+    end
+    it 'should redirect index when not logged in' do
+      expect(response).to redirect_to login_url
+    end
   end
 
-  it 'should get new' do
-    get :new
-    expect(response).to have_http_status :success
+  context 'get new' do
+    before do
+      get :new
+    end
+    it 'should get new' do
+      expect(response).to have_http_status :success
+    end
   end
 
-  it 'should redirect edit when not logged in' do
-    get :edit, id: user
-    expect(flash).to_not be_empty
-    expect(response).to redirect_to login_url
+  context 'edit and update when not logged in' do
+    let(:user) { create :tsubasa }
+    context 'get edit id of user' do
+      before do
+        get :edit, id: user
+      end
+      it 'should redirect edit when not logged in' do
+        expect(flash).to_not be_empty
+        expect(response).to redirect_to login_url
+      end
+    end
+
+    context 'patch update id of user' do
+      before do
+        patch :update, id: user, user: { name: user.name, email: user.email }
+      end
+      it 'should redirect update when not logged in' do
+        expect(flash).to_not be_empty
+        expect(response).to redirect_to login_url
+      end
+    end
   end
 
-  it 'should redirect update when not logged in' do
-    patch :update, id: user, user: { name: user.name, email: user.email }
-    expect(flash).to_not be_empty
-    expect(response).to redirect_to login_url
+  context 'edit and update when logged in' do
+    let(:user) { create :user }
+    let(:other_user) { create :sayami }
+    before do
+      log_in_as(other_user)
+    end
+    context 'edit edit id of user' do
+      before do
+        get :edit, id: user
+      end
+      it 'should redirect edit when logged in as wrong user' do
+        expect(flash).to be_empty
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'patch update id of user' do
+      before do
+        patch :update, id: user, user: { name: user.name, email: user.email }
+      end
+      it 'should redirect update when logged in as wrong user' do
+        expect(flash).to be_empty
+        expect(response).to redirect_to root_url
+      end
+    end
   end
 
-  it 'should redirect edit when logged in as wrong user' do
-    log_in_as(other_user)
-    get :edit, id: user
-    expect(flash).to be_empty
-    expect(response).to redirect_to root_url
+  context 'redirect destroy' do
+    let(:other_user) { create :sayami }
+    let(:user) { create :tsubasa }
+    before do
+      user
+    end
+    it 'should redirect destroy when not logged in' do
+      expect { delete :destroy, id: user }.to_not change { User.count }
+      expect(response).to redirect_to login_url
+    end
+    context 'destroy when logged in' do
+      before do
+        log_in_as(other_user)
+      end
+      it 'should redirect destroy when logged in as a non-adin' do
+        expect { delete :destroy, id: user }.to_not change { User.count }
+        expect(response).to redirect_to root_url
+      end
+    end
   end
 
-  it 'should redirect update when logged in as wrong user' do
-    log_in_as(other_user)
-    patch :update, id: user, user: { name: user.name, email: user.email }
-    expect(flash).to be_empty
-    expect(response).to redirect_to root_url
-  end
+  context 'following and followers' do
+    let(:user) { create :tsubasa }
+    context 'get following id of user' do
+      before do
+        get :following, id: user
+      end
+      it 'should reidrect following when not logged in' do
+        expect(response).to redirect_to login_url
+      end
+    end
 
-  it 'should redirect destroy whtn not logged in' do
-    expect { delete :destroy, id: user }.to_not change { User.count }
-    expect(response).to redirect_to login_url
-  end
-
-  it 'should redirect destroy when logged in as a non-adin' do
-    log_in_as(other_user)
-    expect { delete :destroy, id: user }.to_not change { User.count }
-    expect(response).to redirect_to root_url
-  end
-
-  it 'should reidrect following when not logged in' do
-    get :following, id: user
-    expect(response).to redirect_to login_url
-  end
-
-  it 'should redirect followers when not logged in' do
-    get :followers, id: user
-    expect(response).to redirect_to login_url
+    context 'get followers id of user' do
+      before do
+        get :followers, id: user
+      end
+      it 'should redirect followers when not logged in' do
+        expect(response).to redirect_to login_url
+      end
+    end
   end
 end


### PR DESCRIPTION
# 対象issue
#35 #36
# 対応内容
controllersのusers_controller_spec.rbのテストコードを修正いたしました。

let!を成るべく使用しないようbeforeで対応
itメソッドの中身はtestコードのみにするためにcontextでブロックを作りbeforeで対応
should redirect destroy whtn not logged inのwhtnのスペルミス対応→when

確認よろしくお願い致します。
# 備考

