### PR TITLE
fixes#35#36fixed user spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User, type: :models do
           user.name = ''
         end
         it 'name should be present' do
-          expect(user).to_not be_valid
+          expect(user).to be_invalid
         end
       end
 
@@ -23,7 +23,7 @@ RSpec.describe User, type: :models do
           user.name = 'a' * 51
         end
         it 'name should not be too long' do
-          expect(user).to_not be_valid
+          expect(user).to be_invalid
         end
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe User, type: :models do
           user.email = ''
         end
         it 'email should be present' do
-          expect(user).to_not be_valid
+          expect(user).to be_invalid
         end
       end
 
@@ -43,7 +43,7 @@ RSpec.describe User, type: :models do
           user.email = 'a' * 244 + '@example.com'
         end
         it 'email should not be too long' do
-          expect(user).to_not be_valid
+          expect(user).to be_invalid
         end
       end
 
@@ -52,7 +52,7 @@ RSpec.describe User, type: :models do
         it 'email validation should accept valid addresses' do
           valid_addresses.each do |valid_address|
             user.email = valid_address
-            expect(user).to be_valid, '#{valid_address.inspect} should be valid'
+            expect(user).to be_valid, "#{valid_address.inspect} should be valid"
           end
         end
       end
@@ -64,7 +64,7 @@ RSpec.describe User, type: :models do
           user.save
         end
         it 'email addresses should be unique' do
-          expect(duplicate_user).to_not be_valid
+          expect(duplicate_user).to be_invalid
         end
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe User, type: :models do
         user.password = user.password_confirmation = 'a' * 5
       end
       it 'password should be present (nonblank)' do
-        expect(user).to_not be_valid
+        expect(user).to be_invalid
       end
     end
 
@@ -121,7 +121,7 @@ RSpec.describe User, type: :models do
 
         # フォローしていないユーザーの投稿を確認
         lana.microposts.each do |post_unfollowed|
-          expect(tsubasa.feed.include?(post_unfollowed)).to_not be_truthy
+          expect(tsubasa.feed.include?(post_unfollowed)).to be_falsey
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,88 +1,129 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :models do
-  let(:user) { User.new(name: 'Example User', email: 'user@example.com', password: 'password', password_confirmation: 'password') }
+  context 'user' do
+    let(:user) { User.new(name: 'Example User', email: 'user@example.com', password: 'password', password_confirmation: 'password') }
 
-  it 'should be valid' do
-    expect(user).to be_valid
-  end
-
-  it 'name should be presentds' do
-    user.name = ' '
-    expect(user).to_not be_valid
-  end
-
-  it 'email should be present' do
-    user.email = ' '
-    expect(user).to_not be_valid
-  end
-
-  it 'name should not be too long' do
-    user.name = 'a' * 51
-    expect(user).to_not be_valid
-  end
-
-  it 'email should not be too long' do
-    user.email = 'a' * 244 + '@example.com'
-    expect(user).to_not be_valid
-  end
-
-  it 'email validation should accept valid addresses' do
-    valid_addresses = ['user@example.com', 'USER@foo.COM', 'A_US-ER@foo.bar.org', 'first.last@foo.jp', 'alice+bob@baz.cn']
-    valid_addresses.each do |valid_address|
-      user.email = valid_address
-      expect(user).to be_valid, '#{valid_address.inspect} should be valid'
-    end
-  end
-
-  it 'email addresses should be unique' do
-    duplicate_user = user.dup
-    duplicate_user.email = user.email.upcase
-    user.save
-    expect(duplicate_user).to_not be_valid
-  end
-
-  it 'password should be present (nonblank)' do
-    user.password = user.password_confirmation = 'a' * 5
-    expect(user).to_not be_valid
-  end
-
-  it 'authenticated? should return false for a user with nil digest' do
-    expect(user).to_not be_authenticated(:remember, '')
-  end
-
-  it 'associated microposts should be destroyed' do
-    user.save
-    user.microposts.create!(content: 'Lorem ipsum')
-    expect { user.destroy }.to change { Micropost.count }.by(-1)
-  end
-
-  it 'should follow and unfollow a user' do
-    tsubasa = create :tsubasa
-    lana = create :lana
-    expect(tsubasa).to_not be_following(lana)
-    tsubasa.follow(lana)
-    expect(tsubasa).to be_following(lana)
-    expect(lana.followers.include?(tsubasa)).to be_truthy
-    tsubasa.unfollow(lana)
-    expect(tsubasa).to_not be_following(lana)
-  end
-
-  it 'feed should have the right posts' do
-    tsubasa = create :tsubasa
-    sayami = create :sayami
-    lana = create :lana
-    sayami.microposts.each do |post_following|
-      expect(tsubasa.feed.include?(post_following)).to be_truthy
+    it 'should be valid' do
+      expect(user).to be_valid
     end
 
-    tsubasa.microposts.each do |post_self|
-      expect(tsubasa.feed.include?(post_self)).to be_truthy
+    context 'name' do
+      context 'present' do
+        before do
+          user.name = ''
+        end
+        it 'name should be present' do
+          expect(user).to_not be_valid
+        end
+      end
+
+      context 'too long' do
+        before do
+          user.name = 'a' * 51
+        end
+        it 'name should not be too long' do
+          expect(user).to_not be_valid
+        end
+      end
     end
 
-    # フォローしていないユーザーの投稿を確認
-    lana.microposts.each do |post_unfollowed|
-      expect(tsubasa.feed.include?(post_unfollowed)).to_not be_truthy
+    context 'email' do
+      context 'present' do
+        before do
+          user.email = ''
+        end
+        it 'email should be present' do
+          expect(user).to_not be_valid
+        end
+      end
+
+      context 'too long' do
+        before do
+          user.email = 'a' * 244 + '@example.com'
+        end
+        it 'email should not be too long' do
+          expect(user).to_not be_valid
+        end
+      end
+
+      context 'accept valid addresses' do
+        let(:valid_addresses) { ['user@example.com', 'USER@foo.COM', 'A_US-ER@foo.bar.org', 'first.last@foo.jp', 'alice+bob@baz.cn'] }
+        it 'email validation should accept valid addresses' do
+          valid_addresses.each do |valid_address|
+            user.email = valid_address
+            expect(user).to be_valid, '#{valid_address.inspect} should be valid'
+          end
+        end
+      end
+
+      context 'unique' do
+        let(:duplicate_user) { user.dup }
+        before do
+          duplicate_user.email = user.email.upcase
+          user.save
+        end
+        it 'email addresses should be unique' do
+          expect(duplicate_user).to_not be_valid
+        end
+      end
+    end
+
+    context 'pssowrd present' do
+      before do
+        user.password = user.password_confirmation = 'a' * 5
+      end
+      it 'password should be present (nonblank)' do
+        expect(user).to_not be_valid
+      end
+    end
+
+    it 'authenticated? should return false for a user with nil digest' do
+      expect(user).to_not be_authenticated(:remember, '')
+    end
+
+    context 'microposts destroyed' do
+      before do
+        user.save
+        user.microposts.create!(content: 'Lorem ipsum')
+      end
+      it 'associated microposts should be destroyed' do
+        expect { user.destroy }.to change { Micropost.count }.by(-1)
+      end
+    end
+
+    context 'follow and unfollow' do
+      let(:tsubasa) { create :tsubasa }
+      let(:lana) { create :lana }
+      it 'should follow and unfollow a user' do
+        expect(tsubasa).to_not be_following(lana)
+        tsubasa.follow(lana)
+        expect(tsubasa).to be_following(lana)
+        expect(lana.followers.include?(tsubasa)).to be_truthy
+        tsubasa.unfollow(lana)
+        expect(tsubasa).to_not be_following(lana)
+      end
+    end
+
+    context 'right posts' do
+      let(:tsubasa) { create :tsubasa }
+      let(:sayami) { create :sayami }
+      let(:lana) { create :lana }
+
+      it 'feed should have the right posts' do
+        sayami.microposts.each do |post_following|
+          expect(tsubasa.feed.include?(post_following)).to be_truthy
+        end
+
+        tsubasa.microposts.each do |post_self|
+          expect(tsubasa.feed.include?(post_self)).to be_truthy
+        end
+
+        # フォローしていないユーザーの投稿を確認
+        lana.microposts.each do |post_unfollowed|
+          expect(tsubasa.feed.include?(post_unfollowed)).to_not be_truthy
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# 対象issue
#35 #36
# 対応内容
modelsのuser_spec.rbのコード修正いたしました。

itの中はテストコードのみにまとめるためにcontextでブロックを作り、letとbeforeで前処理を分けました。

contextでブロックを作成したのですが、nameはname,emailはemailでテスト分けをいたしました。

また、スペルミスを見つけたので、修正いたしました。
it 'name should be presents' do　→　it 'name should be present' do


# 備考

