### PR TITLE
fixes#38fixed stats bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,10 @@ group :development, :test do
   gem 'spring',      '1.1.3'
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'rubocop', '~>0.37.2', require: false
+  gem 'rspec-rails', '~>3.4.0'
 end
 
 group :test do
-  gem 'rspec-rails', '~>3.4.0'
   gem 'capybara', '~>2.6.2'
   gem 'poltergeist', '~>1.8.1'
   gem 'database_cleaner', '~>1.5.1'


### PR DESCRIPTION
# 対象issue
#38
# 対応内容
rake statsでspecを表示できるよう修正いたしました。

Gemfileのrspec-railsのgroupをtestからdevelopment, :testへと移行したところ
rake/statsでspecの情報を表示させることができました。
参考ページ　https://github.com/rspec/rspec-rails/issues/271

ご確認よろしくお願い致します。

# 備考

