### PR TITLE
fixes#40add sessions controller create

### DIFF
--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe SessionsController, type: :controller do
   let(:user) { create :tsubasa }
   context 'get new' do
     before do
-      get :new
+      post :new
     end
-    it 'should get new' do
+    it 'should post new' do
       expect(response).to have_http_status :success
     end
   end
 
-  context 'get create' do
+  context 'post create' do
     context 'invalid information' do
       before do
-        get :create, session: { email: user.email }
+        post :create, session: { email: user.email }
       end
       it 'create should when not user login' do
         expect(response).to render_template(:new)
@@ -23,9 +23,9 @@ RSpec.describe SessionsController, type: :controller do
       end
     end
 
-    context 'get create valid information' do
+    context 'post create valid information' do
       before do
-        get :create, session: { email: user.email, password:user.password, remember_me: '1'}
+        post :create, session: { email: user.email, password:user.password, remember_me: '1'}
       end
       context 'invalid account activations' do
         let(:user){ create :tsubasa, activated: false, activated_at: nil }
@@ -42,16 +42,15 @@ RSpec.describe SessionsController, type: :controller do
           expect(cookies['remember_token']).to be_present
         end
       end
-
-      context 'remember_token off' do
-        before do
-          get :create, session: { email: user.email, password:user.password, remember_me: '0'}
-        end
-        it 'create should when user login remember_me off' do
-          expect(response).to redirect_to user_path(user)
-          expect(logged_in?).to be_truthy
-          expect(cookies['remember_token']).to be_blank
-        end
+    end
+    context 'remember_token off' do
+      before do
+        post :create, session: { email: user.email, password:user.password, remember_me: '0'}
+      end
+      it 'create should when user login remember_me off' do
+        expect(response).to redirect_to user_path(user)
+        expect(logged_in?).to be_truthy
+        expect(cookies['remember_token']).to be_blank
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   context 'get create' do
-
     context 'invalid information' do
       before do
         get :create, session: { email: user.email }
@@ -36,11 +35,23 @@ RSpec.describe SessionsController, type: :controller do
           expect(logged_in?).to be_falsey
         end
       end
+      context 'remember_token on' do
+        it 'create should when user login rememeber_me on' do
+          expect(response).to redirect_to user_path(user)
+          expect(logged_in?).to be_truthy
+          expect(cookies['remember_token']).to be_present
+        end
+      end
 
-      it 'create should when user login' do
-        expect(response).to redirect_to user_path(user)
-        expect(logged_in?).to be_truthy
-        expect(cookies['remember_token']).to be_present
+      context 'remember_token off' do
+        before do
+          get :create, session: { email: user.email, password:user.password, remember_me: '0'}
+        end
+        it 'create should when user login remember_me off' do
+          expect(response).to redirect_to user_path(user)
+          expect(logged_in?).to be_truthy
+          expect(cookies['remember_token']).to be_blank
+        end
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,12 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
+  let(:user) { create :tsubasa }
   context 'get new' do
     before do
       get :new
     end
     it 'should get new' do
       expect(response).to have_http_status :success
+    end
+  end
+
+  context 'get create' do
+
+    context 'invalid information' do
+      before do
+        get :create, session: { email: user.email }
+      end
+      it 'create should when not user login' do
+        expect(response).to render_template(:new)
+        expect(logged_in?).to be_falsey
+        expect(flash).to_not be_empty
+      end
+    end
+
+    context 'get create valid information' do
+      before do
+        get :create, session: { email: user.email, password:user.password, remember_me: '1'}
+      end
+      context 'invalid account activations' do
+        let(:user){ create :tsubasa, activated: false, activated_at: nil }
+        it 'create should when not user login invalid account activations' do
+          expect(response).to redirect_to root_url
+          expect(flash).to_not be_empty
+          expect(logged_in?).to be_falsey
+        end
+      end
+
+      it 'create should when user login' do
+        expect(response).to redirect_to user_path(user)
+        expect(logged_in?).to be_truthy
+        expect(cookies['remember_token']).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
# 対象issue
#40
# 対応内容
controllersのsessions_controller_spec.rbのcreateメソッドのテストコードを追加いたしました。

context 'get create' doでcreateメソッドのtestをくくっております。
itメソッドのcreate should when not user loginはユーザーの情報が一致しないで、エラーになるテストです。

itメソッドのcreate should when not user login invalid account activationsは、ユーザー情報は一致しているがまだ有効化されていないユーザーでのエラーテストとなっております。

itメソッドのcreate should when user loginは正常系テストです。
正常系テストではremember_meをチェックした形にしました。
これはcookiesにremember_tokenが入っているかのテストを実行しました。

ご確認よろしくお願い致します。
# 備考

