### PR TITLE
fixes#40add passowrd resets controller spec create

### DIFF
--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,7 +1,6 @@
 <h1>Password reset</h1>
 
 <p>To reset your password click the link below:</p>
-
 <%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
                                                       email: @user.email) %>
 

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PasswordResetsController, type: :controller do
       expect(response).to redirect_to root_url
       expect(flash).to be_present
       expect(user.reload.reset_digest).to be_present
+      expect(ActionMailer::Base.deliveries.size).to eq 1
     end
   end
   context 'get create not password reset' do

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe PasswordResetsController, type: :controller do
     it 'create shoule when user password reset' do
       expect(response).to redirect_to root_url
       expect(flash).to be_present
-      expect(user.create_reset_digest).to be_present
-      expect(user.send_password_reset_email).to be_present
+      expect(user.reload.reset_digest).to be_present
     end
   end
   context 'get create not password reset' do

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe PasswordResetsController, type: :controller do
   let(:user) { create :tsubasa }
   context 'get create password reset' do
     before do
+      ActionMailer::Base.deliveries.clear
       post :create, password_reset: { email: user.email }
     end
     it 'create shoule when user password reset' do


### PR DESCRIPTION
# 対象issue
#40
# 対応内容
controllersのpassword_resets_controllerのcreateアクションに対して、テストを追加いたしました。

itメソッドのcreate shoule when user password resetは通常系でuser.emailが正しくパスワード変更をパスするテストです。

itメソッドのcreate should when not user password resetは異常系でuserのemailアドレスが正しくない場合のテストです。
ご確認よろしくお願い致します。

# 備考

