### PR TITLE
fixes#40add password resets controller edit

### DIFF
--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -32,4 +32,14 @@ RSpec.describe PasswordResetsController, type: :controller do
       expect(flash).to be_present
     end
   end
+
+  context 'get edit' do
+    before do
+      user.create_reset_digest
+      get :edit, id: user.reset_token, email: user.email
+    end
+    it 'edit check status code' do
+      expect(response).to have_http_status :success
+    end
+  end
 end


### PR DESCRIPTION
# 対象issue
#40
# 対応内容
controllersのpassword_resets_controller_spec.rbのeditアクションを追加いたしました。

前処理でuser.create_reset_digestでidでもあるreset_tokenを作成しました。
ステータスコード検証のみのテストとなっております。

ご確認お願い致します。
# 備考

