### PR TITLE
fixes#40fixed password resets controller spec

### DIFF
--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -46,33 +46,36 @@ RSpec.describe PasswordResetsController, type: :controller do
   context 'update user password' do
     before do
       user.create_reset_digest
-      patch :update, id: user.reset_token, email: user.email,user: { password: 'password', password_confirmation: 'password' }
+      patch :update, id: user.reset_token, email: user.email, user: { password: 'foobaz', password_confirmation: 'foobaz' }
     end
     it 'update should when user password preset' do
       expect(response).to redirect_to user_url(user)
       expect(flash).to be_present
+      expect(user.reload.authenticate('foobaz')).to be_truthy
       expect(logged_in?).to be_truthy
     end
   end
 
   shared_examples_for 'invalid reset' do
+    before do
+      user.create_reset_digest
+      patch :update, id: user.reset_token, email: user.email, user: { password: password, password_confirmation: confirmation }
+    end
     it 'update should not user password reset' do
       expect(response).to render_template(:edit)
       expect(user.errors).to be_truthy
     end
   end
-  context 'update missed by noting password' do
-    before do
-      user.create_reset_digest
-      patch :update, id: user.reset_token, email: user.email,user: { password: '', password_confirmation: '' }
+  context 'update missed by without password' do
+    it_behaves_like 'invalid reset' do
+      let(:password) { '' }
+      let(:confirmation) { '' }
     end
-    it_behaves_like 'invalid reset'
   end
   context 'update missed by invalid password' do
-    before do
-      user.create_reset_digest
-      patch :update, id: user.reset_token, email: user.email,user: { password: 'foobaz', password_confirmation: 'barfoo' }
+    it_behaves_like 'invalid reset' do
+      let(:password) { 'foobaz' }
+      let(:confirmation) { 'barfoo' }
     end
-    it_behaves_like 'invalid reset'
   end
 end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -42,4 +42,37 @@ RSpec.describe PasswordResetsController, type: :controller do
       expect(response).to have_http_status :success
     end
   end
+
+  context 'update user password' do
+    before do
+      user.create_reset_digest
+      patch :update, id: user.reset_token, email: user.email,user: { password: 'password', password_confirmation: 'password' }
+    end
+    it 'update should when user password preset' do
+      expect(response).to redirect_to user_url(user)
+      expect(flash).to be_present
+      expect(logged_in?).to be_truthy
+    end
+  end
+
+  shared_examples_for 'invalid reset' do
+    it 'update should not user password reset' do
+      expect(response).to render_template(:edit)
+      expect(user.errors).to be_truthy
+    end
+  end
+  context 'update missed by noting password' do
+    before do
+      user.create_reset_digest
+      patch :update, id: user.reset_token, email: user.email,user: { password: '', password_confirmation: '' }
+    end
+    it_behaves_like 'invalid reset'
+  end
+  context 'update missed by invalid password' do
+    before do
+      user.create_reset_digest
+      patch :update, id: user.reset_token, email: user.email,user: { password: 'foobaz', password_confirmation: 'barfoo' }
+    end
+    it_behaves_like 'invalid reset'
+  end
 end


### PR DESCRIPTION
# 対象issue
#40
# 対応内容
controllersのpassword_resets_controller.rbのupdateアクションに対するテストを追加いたしました。

前処理でuser.create_reset_digestでreset_tokenを作成し、patch :updateで取得できるようにしました。

正常系のテスト（update user password）と
異常系はパスワードがからの場合（update missed by noting password）と、
パスワードが無効な場合（update missed by invalid password）のテストを実行いたしました。
異常系のテストはshared_examples_forでまとめました。

ご確認よろしくお願い致します。
# 備考

