### PR TITLE
fixes#40fixed users controller create

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UsersController, type: :controller do
 
   context 'create user' do
     context 'create valid user' do
-      let(:user_params) { User.find_by(email: 'tun@example.com') }
+      #let(:user) { User.find_by(email: 'tun@example.com') }
       before do
         ActionMailer::Base.deliveries.clear
       end
@@ -37,8 +37,9 @@ RSpec.describe UsersController, type: :controller do
         expect(response).to redirect_to root_url
         expect(flash).to be_present
         expect(ActionMailer::Base.deliveries.size).to eq(1)
-        expect(user_params.email).to eq('tun@example.com')
-        expect(user_params.authenticate('password')).to be_truthy
+        user = User.find_by(email: 'tun@example.com')
+        expect(user.email).to eq('tun@example.com')
+        expect(user.authenticate('password')).to be_truthy
       end
     end
     context 'create invalid user' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -26,6 +26,45 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
+  context 'create user' do
+    context 'create valid user' do
+      before do
+        ActionMailer::Base.deliveries.clear
+        post :create, user: { name: 'User Example', email: 'user@example.com', password: 'password', password_confirmation: 'password' }
+      end
+      it 'cleat new user' do
+        expect(response).to redirect_to root_url
+        expect(flash).to be_present
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+      end
+    end
+    context 'create invalid user' do
+      shared_examples_for 'invalid user' do
+        before do
+          post :create, user: { name: 'User Example', email: email, password: password, password_confirmation: confirmation }
+        end
+        it 'create not new user' do
+          expect(response).to render_template(:new)
+        end
+      end
+      context 'invalid email' do
+        it_behaves_like 'invalid user' do
+          let(:email) { 'user@example' }
+          let(:password) { 'password' }
+          let(:confirmation) { 'password' }
+        end
+      end
+      context 'invalid password' do
+        it_behaves_like 'invalid user' do
+          let(:email) { 'user@example.com' }
+          let(:password) { 'pass' }
+          let(:confirmation) { 'word' }
+        end
+      end
+    end
+  end
+
+
   context 'edit and update when not logged in' do
     context 'get edit id of user' do
       before do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,14 +28,17 @@ RSpec.describe UsersController, type: :controller do
 
   context 'create user' do
     context 'create valid user' do
+      let(:user_params) { User.find_by(email: 'tun@example.com') }
       before do
         ActionMailer::Base.deliveries.clear
       end
       it 'cleat new user' do
-        expect { post :create, user: { name: 'User Example', email: 'user@example.com', password: 'password', password_confirmation: 'password' } }.to change { User.count }.by(1)
+        expect { post :create, user: { name: 'User Example', email: 'tun@example.com', password: 'password', password_confirmation: 'password' } }.to change { User.count }.by(1)
         expect(response).to redirect_to root_url
         expect(flash).to be_present
         expect(ActionMailer::Base.deliveries.size).to eq(1)
+        expect(user_params.email).to eq('tun@example.com')
+        expect(user_params.authenticate('password')).to be_truthy
       end
     end
     context 'create invalid user' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe UsersController, type: :controller do
     context 'create valid user' do
       before do
         ActionMailer::Base.deliveries.clear
-        post :create, user: { name: 'User Example', email: 'user@example.com', password: 'password', password_confirmation: 'password' }
       end
       it 'cleat new user' do
+        expect { post :create, user: { name: 'User Example', email: 'user@example.com', password: 'password', password_confirmation: 'password' } }.to change { User.count }.by(1)
         expect(response).to redirect_to root_url
         expect(flash).to be_present
         expect(ActionMailer::Base.deliveries.size).to eq(1)
@@ -58,7 +58,22 @@ RSpec.describe UsersController, type: :controller do
         it_behaves_like 'invalid user' do
           let(:email) { 'user@example.com' }
           let(:password) { 'pass' }
-          let(:confirmation) { 'word' }
+          let(:confirmation) { 'pass' }
+        end
+      end
+      context 'same params email' do
+        let(:params) { User.find_by(email: 'tsubasa@example.com') }
+        it_behaves_like 'invalid user' do
+          let(:email) { params }
+          let(:password) { 'foobar' }
+          let(:confirmation) { 'foobar' }
+        end
+      end
+      context 'invalid confirmation' do
+        it_behaves_like 'invalid user' do
+          let(:email) { 'user@example' }
+          let(:password) { 'password' }
+          let(:confirmation) { 'foobar' }
         end
       end
     end


### PR DESCRIPTION
# 対象issue
#40
# 対応内容
controllers のusers_controllerのcreateアクションのテストを追加いたしました。
正常系と異常系はメールアドレスが無効の場合とパスワードがconfirmationと一致していないので分けました。
また、異常系はshared_examples_forでコードをまとめました。
確認よろしくお願い致します。
# 備考

