### PR TITLE
fixes#40fixed add microposts controller create/destroy

### DIFF
--- a/spec/controllers/microposts_controller_spec.rb
+++ b/spec/controllers/microposts_controller_spec.rb
@@ -1,32 +1,68 @@
 require 'rails_helper'
 
 RSpec.describe MicropostsController, type: :controller do
-
-  context 'create and destroy when not logged in' do
-    let!(:micropost) { create :orange }
-
-    it 'should redirect create when not logged in' do
-      expect { post :create, micropost: { content: 'Lorem ipsum' } }.to_not change { Micropost.count }
-      expect(response).to redirect_to login_url
+  let(:micropost) { create :orange }
+  let(:user) { create :tsubasa }
+  context 'create action' do
+    before do
+      micropost
     end
-
-    it 'should redirect destroy when not logged in' do
-      expect { delete :destroy, id: micropost }.to_not change { Micropost.count }
-      expect(response).to redirect_to login_url
+    context 'create micropost' do
+      before do
+        log_in_as(user)
+      end
+      it 'should redirec create micropost' do
+        expect { post :create, micropost: { content: 'micropost create', id: user } }.to change { Micropost.count}.by(1)
+        expect(flash).to be_present
+        expect(response).to redirect_to root_url
+      end
+    end
+    context 'when not logged in' do
+      it 'should redirect create when not logged in' do
+        expect { post :create, micropost: { content: 'Lorem ipsum' } }.to_not change { Micropost.count }
+        expect(response).to redirect_to login_url
+      end
+    end
+    context 'create not micropost' do
+      before do
+        log_in_as(user)
+      end
+      it 'should no create micropost' do
+        expect { post :create, micropost: { content: 'a'*141, id: user } }.to_not change  { Micropost.count }
+        expect(response).to render_template 'static_pages/home'
+      end
     end
   end
 
-  context 'wrong micropost destroy' do
-    let(:user) { build :tsubasa }
-    let!(:ants) { create :ants }
-    let!(:micropost) { create :orange }
-    before do
-      log_in_as(user)
+  context 'destroy action' do
+    context 'destroy micropost' do
+      let(:user) { create :tsubasa_with_microposts }
+      before do
+        log_in_as(user)
+      end
+      it 'should redirect destroy for wrong micropost' do
+        expect { delete :destroy, id: user }.to change { Micropost.count }.by(-1)
+        expect(response).to redirect_to root_url
+        expect(flash).to be_present
+      end
     end
 
-    it 'should redirect destroy for wrong micropost' do
-      expect { delete :destroy, id: ants }.to_not change { Micropost.count }
-      expect(response).to redirect_to root_url
+    context 'when not logged in' do
+      it 'should redirect destroy when not logged in' do
+        expect { delete :destroy, id: user }.to_not change { Micropost.count }
+        expect(response).to redirect_to login_url
+      end
+    end
+
+    context 'without micropost' do
+      let(:other) { create :mallory }
+      before do
+        log_in_as(other)
+      end
+      it 'should redirect destroy for wrong micropost' do
+        expect { delete :destroy, id: other }.to_not change { Micropost.count }
+        expect(response).to redirect_to root_url
+      end
     end
   end
 end

--- a/spec/controllers/microposts_controller_spec.rb
+++ b/spec/controllers/microposts_controller_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe MicropostsController, type: :controller do
   end
 
   context 'destroy action' do
-    let(:user_microposts) { create :tsubasa_with_microposts }
+    let(:micropost) { create :orange }
     context 'destroy micropost' do
       before do
         log_in_as(user)
-        user_microposts
+        micropost
       end
       it 'should redirect destroy for wrong micropost' do
-        expect { delete :destroy, id: user_microposts }.to change { Micropost.count }.by(-1)
+        expect { delete :destroy, id: micropost }.to change { Micropost.count }.by(-1)
         expect(response).to redirect_to root_url
         expect(flash).to be_present
       end
@@ -46,10 +46,10 @@ RSpec.describe MicropostsController, type: :controller do
 
     context 'when not logged in' do
       before do
-        user_microposts
+        micropost
       end
       it 'should redirect destroy when not logged in' do
-        expect { delete :destroy, id: user_microposts }.to_not change { Micropost.count }
+        expect { delete :destroy, id: micropost }.to_not change { Micropost.count }
         expect(response).to redirect_to login_url
       end
     end
@@ -58,10 +58,10 @@ RSpec.describe MicropostsController, type: :controller do
       let(:other) { create :mallory }
       before do
         log_in_as(other)
-        user_microposts
+        micropost
       end
       it 'should redirect destroy for wrong micropost' do
-        expect { delete :destroy, id: user_microposts }.to_not change { Micropost.count }
+        expect { delete :destroy, id: micropost }.to_not change { Micropost.count }
         expect(response).to redirect_to root_url
       end
     end

--- a/spec/controllers/microposts_controller_spec.rb
+++ b/spec/controllers/microposts_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MicropostsController, type: :controller do
 
         context 'destroy mictropost redirect referrer' do
           before do
-            controller.request.receive(:referrer).and_return('/test')
+            allow(controller.request).to receive(:referrer).and_return('/test')
           end
           it_behaves_like 'should destroy micropost' do
             let(:routes) { '/test' }

--- a/spec/controllers/microposts_controller_spec.rb
+++ b/spec/controllers/microposts_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MicropostsController, type: :controller do
 
         context 'destroy mictropost redirect referrer' do
           before do
-            controller.request.should_receive(:referer).and_return('/test')
+            controller.request.receive(:referrer).and_return('/test')
           end
           it_behaves_like 'should destroy micropost' do
             let(:routes) { '/test' }

--- a/spec/controllers/microposts_controller_spec.rb
+++ b/spec/controllers/microposts_controller_spec.rb
@@ -33,14 +33,31 @@ RSpec.describe MicropostsController, type: :controller do
   context 'destroy action' do
     let(:micropost) { create :orange }
     context 'destroy micropost' do
-      before do
-        log_in_as(user)
-        micropost
-      end
-      it 'should redirect destroy for wrong micropost' do
-        expect { delete :destroy, id: micropost }.to change { Micropost.count }.by(-1)
-        expect(response).to redirect_to root_url
-        expect(flash).to be_present
+      shared_examples_for 'should destroy micropost' do
+        before do
+          log_in_as(user)
+          micropost
+        end
+        it 'should redirect destroy for wrong micropost' do
+          expect { delete :destroy, id: micropost }.to change { Micropost.count }.by(-1)
+          expect(response).to redirect_to routes
+          expect(flash).to be_present
+        end
+
+        context 'destroy mictropost redirect root_url' do
+          it_behaves_like 'should destroy micropost' do
+            let(:routes) { root_url }
+          end
+        end
+
+        context 'destroy mictropost redirect referrer' do
+          before do
+            controller.request.should_receive(:referer).and_return('/test')
+          end
+          it_behaves_like 'should destroy micropost' do
+            let(:routes) { '/test' }
+          end
+        end
       end
     end
 

--- a/spec/controllers/microposts_controller_spec.rb
+++ b/spec/controllers/microposts_controller_spec.rb
@@ -1,18 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe MicropostsController, type: :controller do
-  let(:micropost) { create :orange }
   let(:user) { create :tsubasa }
   context 'create action' do
-    before do
-      micropost
-    end
     context 'create micropost' do
       before do
         log_in_as(user)
       end
       it 'should redirec create micropost' do
-        expect { post :create, micropost: { content: 'micropost create', id: user } }.to change { Micropost.count}.by(1)
+        expect { post :create, micropost: { content: 'micropost create' } }.to change { Micropost.count}.by(1)
         expect(flash).to be_present
         expect(response).to redirect_to root_url
       end
@@ -28,28 +24,32 @@ RSpec.describe MicropostsController, type: :controller do
         log_in_as(user)
       end
       it 'should no create micropost' do
-        expect { post :create, micropost: { content: 'a'*141, id: user } }.to_not change  { Micropost.count }
+        expect { post :create, micropost: { content: 'a'*141 } }.to_not change  { Micropost.count }
         expect(response).to render_template 'static_pages/home'
       end
     end
   end
 
   context 'destroy action' do
+    let(:user_microposts) { create :tsubasa_with_microposts }
     context 'destroy micropost' do
-      let(:user) { create :tsubasa_with_microposts }
       before do
         log_in_as(user)
+        user_microposts
       end
       it 'should redirect destroy for wrong micropost' do
-        expect { delete :destroy, id: user }.to change { Micropost.count }.by(-1)
+        expect { delete :destroy, id: user_microposts }.to change { Micropost.count }.by(-1)
         expect(response).to redirect_to root_url
         expect(flash).to be_present
       end
     end
 
     context 'when not logged in' do
+      before do
+        user_microposts
+      end
       it 'should redirect destroy when not logged in' do
-        expect { delete :destroy, id: user }.to_not change { Micropost.count }
+        expect { delete :destroy, id: user_microposts }.to_not change { Micropost.count }
         expect(response).to redirect_to login_url
       end
     end
@@ -58,9 +58,10 @@ RSpec.describe MicropostsController, type: :controller do
       let(:other) { create :mallory }
       before do
         log_in_as(other)
+        user_microposts
       end
       it 'should redirect destroy for wrong micropost' do
-        expect { delete :destroy, id: other }.to_not change { Micropost.count }
+        expect { delete :destroy, id: user_microposts }.to_not change { Micropost.count }
         expect(response).to redirect_to root_url
       end
     end


### PR DESCRIPTION
# 対象issue
#40 
# 対応内容
controllersのmicroposts_controller_spec.rbのcreate,destroyアクションを追加しました。

今回はdestroyアクションとcreateアクションの異常系と正常系のテストを追加しました。
まずいっきに追加した理由としては、create、destroyアクションのアクションごとにわけるため、二つ同時に修正した方がわかりやすいと思い二つとも修正いたしました。

createアクションは、正常系と異常系は、ログインされていない状態でのcreateした時と、文字数オーバーした時のテストを実行致しました。

destroyアクションは、正常系と異常系は、ログインしていないユーザーがdestroyした際と、ログインしているが、そもそもmictropostsがない場合のテストを実行いたしました。

確認お願い致します。
# 備考

