### PR TITLE
fixes models user reset figest

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -137,6 +137,21 @@ RSpec.describe User, type: :models do
   end
 
   describe '#create_reset_digest' do
+    context 'when create reset digest' do
+      let(:time_now) { Time.zone.local(2016,3,7,18,0,0) }
+      before do
+        user.save
+        Timecop.freeze(time_now) do
+          user.create_reset_digest
+        end
+      end
+      it 'user have reset digest' do
+        expect(user.reset_token).to be_present
+        expect(user.reset_digest).to be_present
+        expect(user.reset_sent_at).to be_present
+        expect(user.reset_sent_at).to eq time_now
+      end
+    end
   end
 
   describe '#send_password_reset_email' do


### PR DESCRIPTION
# 対象issue

# 対応内容
modelsのuser.rbのcreate_reset_digestメソッドに対するtestを追加いたしました。

timecopをしようして、reset_sent_atカラムのTime.zone.nowをテストいたしました。
また、reset_digestとreset_tokenの存在性のテストも実行いたしました。

timecopのGemfileの設定が含まれているということで、新しいブランチを作成し、
cherry-pickで先ほどのコミットを読み込み、新たに、プルリクエスを出しました。
ご確認お願い致します。
# 備考

